### PR TITLE
Adding Terraform version to RUNTIME_VERSIONS exported variable

### DIFF
--- a/build_spec_build_runner_runtime_versions.yml
+++ b/build_spec_build_runner_runtime_versions.yml
@@ -30,5 +30,6 @@ steps:
       echo "rails version" &>> ${runtimefile} && rails -v &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
       echo "php version" &>> ${runtimefile} && php --version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
       echo "android sdk version" &>> ${runtimefile} && ${ANDROID_HOME}/tools/bin/sdkmanager --version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile}
+      terraform version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile}
       cat ${runtimefile} && export RUNTIME_VERSIONS=`cat ${runtimefile}`
       rm -f ${runtimefile}

--- a/build_spec_build_runner_runtime_versions.yml
+++ b/build_spec_build_runner_runtime_versions.yml
@@ -29,7 +29,7 @@ steps:
       echo "ruby version" &>> ${runtimefile} && ruby -v &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
       echo "rails version" &>> ${runtimefile} && rails -v &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
       echo "php version" &>> ${runtimefile} && php --version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
-      echo "android sdk version" &>> ${runtimefile} && ${ANDROID_HOME}/tools/bin/sdkmanager --version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile}
+      echo "android sdk version" &>> ${runtimefile} && ${ANDROID_HOME}/tools/bin/sdkmanager --version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile} && \
       terraform version &>> ${runtimefile} && printf "\n\n" &>> ${runtimefile}
       cat ${runtimefile} && export RUNTIME_VERSIONS=`cat ${runtimefile}`
       rm -f ${runtimefile}


### PR DESCRIPTION
**Problem Statement**
Currently terraform version information is not being displayed in the canary logs of dlc-build-canary-build-runner-runtime-version-info-prod canary test. This is because this information wasn't being added to RUNTIME_VERSIONS exported variable.

**Tickets**
[DLCBLD-3743](https://jira.oci.oraclecorp.com/browse/DLCBLD-3743)

**Changes Made**
Added Terraform version to RUNTIME_VERSIONS exported variable in build spec file

**Testing**
Ran a build run with the changed build spec file and checked logs to confirm that terraform version is being echoed. See screenshot below:
![image](https://user-images.githubusercontent.com/32415315/176116694-9e346b78-f7be-4fcd-9e7e-db7009d598cc.png)
