### PR TITLE
Chchsrin test python build

### DIFF
--- a/DockerfilePython
+++ b/DockerfilePython
@@ -1,5 +1,5 @@
 FROM iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:1.0
-apt-get update -y
+RUN apt-get update -y
 RUN apt-get install wget -y
 RUN apt-get install wget -y
 RUN apt-get install curl -y

--- a/DockerfilePython
+++ b/DockerfilePython
@@ -1,4 +1,6 @@
 FROM iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:1.0
+RUN apt-get update
+RUN apt-get install wget -y
 RUN apt-get install wget -y
 RUN apt-get install curl -y
 RUN wget https://gitlab.com/dlcbld/deliver-artifact-test/-/blob/build-deliver-trigger-test/build_spec_ocir.yml

--- a/DockerfilePython
+++ b/DockerfilePython
@@ -1,4 +1,4 @@
-FROM iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:1.0
+FROM iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:2.0-slim-bullseye
 RUN apt-get update -y
 RUN apt-get install wget -y
 RUN apt-get install wget -y

--- a/DockerfilePython
+++ b/DockerfilePython
@@ -1,5 +1,5 @@
 FROM iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:1.0
-RUN apt-get update
+apt-get update -y
 RUN apt-get install wget -y
 RUN apt-get install wget -y
 RUN apt-get install curl -y


### PR DESCRIPTION
The apt-get install command was failing because of outdated repositories. Included apt-get update command but it started failing due to debian bug. Hence, updated the base image using below commands and updated the base image in the DockerfilePython.
```
docker pull python:3.9-slim-bullseye
docker tag python:3.9-slim-bullseye iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:2.0-slim-bullseye
oci raw-request --profile oc1 --auth security_token --http-method GET --target-uri https://iad.ocir.io/20180419/docker/token | jq -r .data.access_token | docker login -u BEARER_TOKEN --password-stdin iad.ocir.io
docker push iad.ocir.io/axg3zewhl95k/do-not-delete-python-39-slim-with-apt:2.0-slim-bullseye
```